### PR TITLE
fix mobile opt of siyuan's li css escaped

### DIFF
--- a/src/components/setting-gui.svelte
+++ b/src/components/setting-gui.svelte
@@ -294,9 +294,9 @@
 
         .b3-list-item__text {
             font-size: 14px;
-            overflow: visible !important;
-            text-overflow: clip !important;
-            white-space: normal !important;
+            overflow: visible !important; /* non chinese opt */
+            text-overflow: clip !important; /* non chinese opt */
+            white-space: normal !important; /* non chinese opt */
             word-wrap: break-word !important;
             display: block !important;
         }

--- a/src/components/setting-gui.svelte
+++ b/src/components/setting-gui.svelte
@@ -219,7 +219,7 @@
     }
 </script>
 
-<div class="fn__flex-1 fn__flex config__panel dn-today-setting">
+<div class="fn__flex-1 fn__flex config__panel">
     <ul class="b3-tab-bar b3-list b3-list--background">
         {#each groups as group}
             <!-- svelte-ignore a11y-no-noninteractive-element-interactions -->
@@ -284,32 +284,30 @@
 
     /* mobile opt */
     @media screen and (max-width: 768px) {
-        :global(.dn-today-setting) {
-        /* ^ needed it to touch b3-list-item and other subs, but also selected to this panel */
-            .config__panel > .b3-tab-bar {
-                width: 100px;
-            }
+        .config__panel > .b3-tab-bar {
+            width: 100px;
+        }
 
-            .b3-list-item__text {
-                font-size: 12px;
-            }
+        .b3-list-item__text {
+            font-size: 12px;
+        }
 
-            .b3-list-item__text {
-                font-size: 14px;
-                overflow: visible !important;
-                text-overflow: clip !important;
-                white-space: normal !important;
-                word-wrap: break-word !important;
-                display: block !important;
-            }
+        .b3-list-item__text {
+            font-size: 14px;
+            overflow: visible !important;
+            text-overflow: clip !important;
+            white-space: normal !important;
+            word-wrap: break-word !important;
+            display: block !important;
+        }
 
-            .b3-list-item {
-                height: 40px !important;
-                line-height: 40px !important;
-                padding: 0 0.5rem !important;
-                white-space: normal !important;
-                word-break: break-word !important;
-            }
+        /* tab div */
+        .b3-list-item {
+            height: 40px !important;
+            line-height: 40px !important; /* at least finger can touch */
+            padding: 0 0.5rem !important;
+            white-space: normal !important;
+            word-break: break-word !important;
         }
     }
 </style>

--- a/src/components/setting-gui.svelte
+++ b/src/components/setting-gui.svelte
@@ -303,8 +303,8 @@
 
         /* tab div */
         .b3-list-item {
-            height: 40px !important;
-            line-height: 40px !important; /* at least finger can touch */
+            height: 40px !important; /* at least finger can touch */
+            line-height: 40px !important;
             padding: 0 0.5rem !important;
             white-space: normal !important;
             word-break: break-word !important;

--- a/src/components/setting-gui.svelte
+++ b/src/components/setting-gui.svelte
@@ -285,7 +285,7 @@
     /* mobile opt */
     @media screen and (max-width: 768px) {
         :global(.dn-today-setting) {
-        /* ^ needed it to touch b3-list-item__text, but also selected to this panel */
+        /* ^ needed it to touch b3-list-item and other subs, but also selected to this panel */
             .config__panel > .b3-tab-bar {
                 width: 100px;
             }

--- a/src/components/setting-gui.svelte
+++ b/src/components/setting-gui.svelte
@@ -219,7 +219,7 @@
     }
 </script>
 
-<div class="fn__flex-1 fn__flex config__panel">
+<div class="fn__flex-1 fn__flex config__panel dn-today-setting">
     <ul class="b3-tab-bar b3-list b3-list--background">
         {#each groups as group}
             <!-- svelte-ignore a11y-no-noninteractive-element-interactions -->
@@ -284,30 +284,32 @@
 
     /* mobile opt */
     @media screen and (max-width: 768px) {
-        .config__panel > .b3-tab-bar {
-            width: 100px;
-        }
+        :global(.dn-today-setting) {
+        /* ^ needed it to touch b3-list-item__text, but also selected to this panel */
+            .config__panel > .b3-tab-bar {
+                width: 100px;
+            }
 
-        :global(.b3-list-item__text) {
-            font-size: 12px;
-        }
+            .b3-list-item__text {
+                font-size: 12px;
+            }
 
-        :global(.b3-list-item__text) {
-            font-size: 14px;
-            overflow: visible !important; /* non chinese opt */
-            text-overflow: clip !important; /* non chinese opt */
-            white-space: normal !important; /* non chinese opt */
-            word-wrap: break-word !important;
-            display: block !important;
-        }
+            .b3-list-item__text {
+                font-size: 14px;
+                overflow: visible !important;
+                text-overflow: clip !important;
+                white-space: normal !important;
+                word-wrap: break-word !important;
+                display: block !important;
+            }
 
-        /* tab div */
-        :global(.b3-list-item) {
-            height: 40px !important; /* at least finger can touch */
-            line-height: 40px !important;
-            padding: 0 0.5rem !important;
-            white-space: normal !important;
-            word-break: break-word !important;
+            .b3-list-item {
+                height: 40px !important;
+                line-height: 40px !important;
+                padding: 0 0.5rem !important;
+                white-space: normal !important;
+                word-break: break-word !important;
+            }
         }
     }
 </style>

--- a/src/index.ts
+++ b/src/index.ts
@@ -200,7 +200,7 @@ export default class DailyNoteTodayPlugin extends Plugin {
         let dialog = new Dialog({
             //@ts-ignore
             title: `${this.i18n.Name}`,
-            content: `<div id="SettingPanel" class="dn-today-setting" style="height: 100%"></div>`,
+            content: `<div id="SettingPanel" style="height: 100%"></div>`,
             width: this.isMobile ? '100%' :'60rem',
             height: this.isMobile ? '100%' :'34rem',
             destroyCallback: () => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -200,7 +200,7 @@ export default class DailyNoteTodayPlugin extends Plugin {
         let dialog = new Dialog({
             //@ts-ignore
             title: `${this.i18n.Name}`,
-            content: `<div id="SettingPanel" style="height: 100%"></div>`,
+            content: `<div id="SettingPanel" class="dn-today-setting" style="height: 100%"></div>`,
             width: this.isMobile ? '100%' :'60rem',
             height: this.isMobile ? '100%' :'34rem',
             destroyCallback: () => {


### PR DESCRIPTION
- in my last PR I mistakenly escaped li's css for setting panel mod and impacted other siyuan elem
- in this PR i use global to make it can still modify siyuan's li, but also selected the panel itself with a new class name
- I don't have your lint tool on my vscode, sorry for the format / indentation
- Sorry for the previous mistake, cuz i thought svelte would isolate them but it didn't do that